### PR TITLE
Remove annotation-api dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [17]
-        include:
-          - platform: ubuntu-latest
-            jdk: 11
-          - platform: macos-latest
-            jdk: 11
+        jdk: [17, 21]
 
     runs-on: ${{ matrix.platform }}
     name: on ${{ matrix.platform }} with JDK ${{ matrix.jdk }}
@@ -32,6 +27,10 @@ jobs:
           java-version: '${{ matrix.jdk }}'
           check-latest: true
           cache: 'maven'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.9.5
       - name: Build with Maven
         env:
           BROWSER: chrome-container

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <spotbugs.version>4.7.3</spotbugs.version>
     <streamex.version>0.8.2</streamex.version>
     <commons.lang.version>3.13.0</commons.lang.version>
-    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <byte-buddy.version>1.14.9</byte-buddy.version>
 
     <!-- Project Test Dependencies Configuration -->
@@ -148,11 +147,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>${javax.annotation-api.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>


### PR DESCRIPTION
Replace `@Generated` from the Jakarta package with my own version of `@Generated` in AssertJ generated code.

Update CI actions to use Java 17 and 21 with Maven 3.9.5.