### PR TITLE
Automatically generate dependency graph for each module

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -1,0 +1,27 @@
+@startuml
+skinparam defaultTextAlignment center
+skinparam rectangle {
+  BackgroundColor<<optional>> beige
+  BackgroundColor<<test>> lightGreen
+  BackgroundColor<<runtime>> lightBlue
+  BackgroundColor<<provided>> lightGray
+}
+rectangle "spotbugs-annotations\n\n4.7.3" as com_github_spotbugs_spotbugs_annotations_jar
+rectangle "jsr305\n\n3.0.2" as com_google_code_findbugs_jsr305_jar
+rectangle "codingstyle-pom\n\n3.32.0-SNAPSHOT" as edu_hm_hafner_codingstyle_pom_pom
+rectangle "error_prone_annotations\n\n2.22.0" as com_google_errorprone_error_prone_annotations_jar
+rectangle "streamex\n\n0.8.2" as one_util_streamex_jar
+rectangle "codingstyle\n\n3.24.0" as edu_hm_hafner_codingstyle_jar
+rectangle "commons-lang3\n\n3.13.0" as org_apache_commons_commons_lang3_jar
+rectangle "commons-io\n\n2.11.0" as commons_io_commons_io_jar
+com_github_spotbugs_spotbugs_annotations_jar -[#000000]-> com_google_code_findbugs_jsr305_jar
+edu_hm_hafner_codingstyle_pom_pom -[#000000]-> com_github_spotbugs_spotbugs_annotations_jar
+edu_hm_hafner_codingstyle_pom_pom -[#000000]-> com_google_errorprone_error_prone_annotations_jar
+edu_hm_hafner_codingstyle_pom_pom -[#000000]-> one_util_streamex_jar
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> com_github_spotbugs_spotbugs_annotations_jar
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> com_google_errorprone_error_prone_annotations_jar
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> org_apache_commons_commons_lang3_jar
+edu_hm_hafner_codingstyle_jar -[#000000]-> commons_io_commons_io_jar
+edu_hm_hafner_codingstyle_pom_pom -[#000000]-> edu_hm_hafner_codingstyle_jar
+edu_hm_hafner_codingstyle_pom_pom -[#000000]-> org_apache_commons_commons_lang3_jar
+@enduml

--- a/pom.xml
+++ b/pom.xml
@@ -616,6 +616,29 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>com.github.ferstl</groupId>
+        <artifactId>depgraph-maven-plugin</artifactId>
+        <version>${depgraph-maven-plugin.version}</version>
+        <configuration>
+          <graphFormat>puml</graphFormat>
+          <classpathScope>compile</classpathScope>
+          <showClassifiers>true</showClassifiers>
+          <showVersions>true</showVersions>
+          <showConflicts>true</showConflicts>
+          <showDuplicates>true</showDuplicates>
+          <outputFileName>dependency-graph</outputFileName>
+          <outputDirectory>${project.basedir}/doc</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>graph</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <version>${revapi-maven-plugin.version}</version>
@@ -708,19 +731,6 @@
               <param>*hashCode</param>
               <param>*toString</param>
             </excludedMethods>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>com.github.ferstl</groupId>
-          <artifactId>depgraph-maven-plugin</artifactId>
-          <version>${depgraph-maven-plugin.version}</version>
-          <configuration>
-            <graphFormat>puml</graphFormat>
-            <scope>compile</scope>
-            <showClassifiers>true</showClassifiers>
-            <showVersions>true</showVersions>
-            <showConflicts>true</showConflicts>
-            <showDuplicates>true</showDuplicates>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
See https://ferstl.github.io/depgraph-maven-plugin for details.

The created file will be placed into the `doc` folder.