### PR TITLE
Exclude libraries that are explicit dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,24 @@
       <groupId>edu.hm.hafner</groupId>
       <artifactId>codingstyle</artifactId>
       <version>${codingstyle.library.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-io</artifactId>
+          <groupId>commons-io</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-lang3</artifactId>
+          <groupId>org.apache.commons</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>error_prone_annotations</artifactId>
+          <groupId>com.google.errorprone</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spotbugs-annotations</artifactId>
+          <groupId>com.github.spotbugs</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -257,6 +275,24 @@
       <artifactId>codingstyle</artifactId>
       <version>${codingstyle.library.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-io</artifactId>
+          <groupId>commons-io</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-lang3</artifactId>
+          <groupId>org.apache.commons</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>error_prone_annotations</artifactId>
+          <groupId>com.google.errorprone</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>spotbugs-annotations</artifactId>
+          <groupId>com.github.spotbugs</groupId>
+        </exclusion>
+      </exclusions>
       <type>test-jar</type>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Simplifies the POM.