### PR TITLE
Fail build on CheckStyle or PMD violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,7 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
@@ -768,6 +769,7 @@
             <id>run-pmd-java</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
               <goal>cpd</goal>
             </goals>
             <phase>verify</phase>
@@ -784,6 +786,7 @@
             <id>run-pmd-tests</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
               <goal>cpd</goal>
             </goals>
             <phase>verify</phase>
@@ -805,6 +808,7 @@
             <id>run-pmd-javascript</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -823,7 +827,6 @@
               </includes>
             </configuration>
           </execution>
-
         </executions>
       </plugin>
       <plugin>
@@ -833,7 +836,7 @@
         <configuration>
           <linkXRef>false</linkXRef>
           <excludeGeneratedSources>true</excludeGeneratedSources>
-          <failsOnError>false</failsOnError>
+          <violationSeverity>warning</violationSeverity>
         </configuration>
         <dependencies>
           <dependency>
@@ -852,7 +855,7 @@
           <execution>
             <id>run-checkstyle-java</id>
             <goals>
-              <goal>checkstyle</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -865,7 +868,7 @@
           <execution>
             <id>run-checkstyle-tests</id>
             <goals>
-              <goal>checkstyle</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -873,6 +876,7 @@
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <configLocation>checkstyle-tests-configuration.xml</configLocation>
               <outputFile>${project.build.directory}/checkstyle-tests/checkstyle-result.xml</outputFile>
+              <sourceDirectories></sourceDirectories>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
To see all CheckStyle and PMD violations in a maven build you need to run maven with option 
`-Dcheckstyle.failOnViolation=false` and `-Dpmd.failOnViolation=false`.