### PR TITLE
Skip flattening of POM in CI builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1049,6 +1049,7 @@
         <pmd.failOnViolation>false</pmd.failOnViolation>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <gpg.skip>true</gpg.skip>
+        <flatten.flatten.skip>true</flatten.flatten.skip>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Otherwise SpotBugs cannot expand the exclusion filter from dependency.