### PR TITLE
Provide OWASP dependency check as profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <depgraph-maven-plugin.version>4.0.3</depgraph-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <git-commit-id-maven-plugin.version>9.0.1</git-commit-id-maven-plugin.version>
+    <dependency-check-maven.version>10.0.4</dependency-check-maven.version>
 
     <!-- OpenRewrite versions   -->
     <rewrite-maven-plugin.version>5.40.2</rewrite-maven-plugin.version>
@@ -1059,6 +1060,29 @@
                 <id>test</id>
                 <goals>
                   <goal>mutationCoverage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>owasp</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>${dependency-check-maven.version}</version>
+            <configuration>
+              <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
+              <format>JSON</format>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
So modules can check their dependencies by calling `mvn verify -Powasp`.

The configuration requires that the environment variable `NVD_API_KEY` contains the API key for the NVD database download. 

In CI workflows you need to specify the following snippet to scan for vulnerabilities:

```
    steps:
      - name: Set up JDK 21
        uses: actions/setup-java@v4
        with:
          distribution: 'temurin'
          java-version: 21
          check-latest: true
          cache: 'maven'
      - name: Set up Maven
        uses: stCarolas/setup-maven@v5
        with:
          maven-version: 3.9.9
      - name: Cache the NVD database
        uses: actions/cache@v3
        with:
          path: ~/.m2/repository/org/owasp/dependency-check-data
          key: dependency-check
      - name: Build with Maven
        env:
          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
        run: mvn -V --color always -ntp clean verify -Pci -Powasp | tee maven.log

``` 