### PR TITLE
Ignore ErrorProne rule `AddNullMarkedToPackageInfo`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -733,6 +733,8 @@
                 NullAway configuration:
                 --> -XepOpt:NullAway:AnnotatedPackages=edu.hm.hafner <!--
                 Disabled ErrorProne rule:
+                --> -Xep:AddNullMarkedToPackageInfo:OFF <!--
+                Disabled ErrorProne rule:
                 --> -Xep:PreferredInterfaceType:OFF <!--
                 Disabled ErrorProne rule:
                 --> -Xep:YodaCondition:OFF <!--


### PR DESCRIPTION
We do not use JSpecify, so it makes no sense to apply this rule.