### PR TITLE
Print PMD warnings in Maven log as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -895,6 +895,7 @@
               </rulesets>
               <includeTests>false</includeTests>
               <minimumTokens>50</minimumTokens>
+              <printFailingErrors>true</printFailingErrors>
               <skip>${pmd.skip}</skip>
             </configuration>
           </execution>
@@ -913,6 +914,7 @@
               </rulesets>
               <includeTests>true</includeTests>
               <minimumTokens>100</minimumTokens>
+              <printFailingErrors>true</printFailingErrors>
               <excludeRoots>
                 <excludeRoot>src/main/java</excludeRoot>
                 <excludeRoot>${project.build.directory}/generated-test-sources/test-annotations</excludeRoot>
@@ -935,6 +937,7 @@
               </rulesets>
               <includeTests>false</includeTests>
               <language>javascript</language>
+              <printFailingErrors>true</printFailingErrors>
               <compileSourceRoots>
                 <compileSourceRoot>${project.basedir}/src/main/resources</compileSourceRoot>
                 <compileSourceRoot>${project.basedir}/src/main/webapp/js</compileSourceRoot>


### PR DESCRIPTION
Show warnings in the log like:

```
[INFO] <<< pmd:3.26.0:check (run-pmd-tests) < :pmd @ java2-abgabe7 <<<
[INFO] 
[INFO] 
[INFO] --- pmd:3.26.0:check (run-pmd-tests) @ java2-abgabe7 ---
[WARNING] PMD Failure: edu.hm.hafner.java2.assignment7.PostalCodeFactoryTest:16 Rule:UseUnderscoresInNumericLiterals Priority:3 Number 85567 should separate every third digit with an underscore.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```