### PR TITLE
Remove JSR 305 annotations exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,12 +187,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>${spotbugs.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
SpotBugs Maven plugin now actively needs the obsolete JSR 305 annotations. So excluding them seems not to work anymore.

See https://github.com/spotbugs/spotbugs/discussions/2345 and https://github.com/spotbugs/spotbugs-maven-plugin/issues/1209