### PR TITLE
Use Sonatype OSS index service with a custom token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1168,6 +1168,9 @@
             <configuration>
               <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <format>JSON</format>
+              <ossIndexUsername>ullrich.hafner@gmail.com</ossIndexUsername>
+              <!--suppress UnresolvedMavenProperty: credentials are provided during CI -->
+              <ossIndexPassword>${env.OSS_INDEX_TOKEN}</ossIndexPassword>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Sonatype now requires authentication while accessing the OSS Index analyzer. The token must be provided as the environment variable `OSS_INDEX_TOKEN`.