### PR TITLE
Add Mockito as Java agent when running integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -851,6 +851,7 @@
             <include>**/*ITest.*</include>
           </includes>
           <reuseForks>false</reuseForks>
+          <argLine>@{argLine} -Djava.util.logging.config.file=logging.properties -javaagent:${org.mockito:mockito-core:jar}</argLine>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The ´argLine´ of surefire could be reused for failsafe plugin.