### PR TITLE
Ensure that Maven release plugin commits will skip CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,8 @@
             <releaseProfiles>release</releaseProfiles>
             <goals>deploy</goals>
             <tagNameFormat>v@{project.version}</tagNameFormat>
+            <scmDevelopmentCommitComment>@{prefix} Prepare for next development iteration [skip ci]</scmDevelopmentCommitComment>
+            <scmReleaseCommitComment>@{prefix} Prepare release [skip ci]</scmReleaseCommitComment>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Otherwise we create a Git conflict during badges creation. 