### PR TITLE
Bump baseline to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <pmd.skip>false</pmd.skip>
 
-    <codingstyle.config.version>5.27.0</codingstyle.config.version>
+    <codingstyle.config.version>6.0.0</codingstyle.config.version>
     <codingstyle.library.version>${codingstyle.config.version}</codingstyle.library.version>
 
     <!-- Project Dependencies Configuration -->


### PR DESCRIPTION
Official Java 17 support ends soon. So it also makes sense to make use of modern Java API. And Jenkins is moving to Java 2 soon, so we will not break anything.