### PR TITLE
Fix typo in PitMute configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
               <param>*toString</param>
             </excludedMethods>
             <features>
-              <feature>+FCSV(csvFile[etc/pitmute.csv]) allowMissingFile[true])</feature>
+              <feature>+FCSV(csvFile[etc/pitmute.csv] allowMissingFile[true])</feature>
             </features>
           </configuration>
           <dependencies>


### PR DESCRIPTION
The option `allowMissingFile[true]` has been ignored due to a typo.