### PR TITLE
Enable PitMute 1.0.0 suppressions via annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,7 @@
             </excludedMethods>
             <features>
               <feature>+FCSV(csvFile[etc/pitmute.csv] allowMissingFile[true])</feature>
+              <feature>+FANNOT</feature>
             </features>
           </configuration>
           <dependencies>


### PR DESCRIPTION
Enable PitMute plugin to suppress mutations via annotations.